### PR TITLE
Add resolution data to location update schemas

### DIFF
--- a/test-resources/geo/enhanced-location-update-schema.json
+++ b/test-resources/geo/enhanced-location-update-schema.json
@@ -20,6 +20,12 @@
       "minLength": 0
     },
 
+    "resolution": {
+      "type": ["object", "null"],
+      "description": "The resolution currently used by the publisher for the given trackable.",
+      "$ref": "https://schemas.ably.com/json/asset-tracking-common/Resolution"
+    },
+
     "intermediateLocations": {
       "type": "array",
       "description": "Predicted locations leading up to this location update.",

--- a/test-resources/geo/enhanced-location-updates/invalid-wrong-type.json
+++ b/test-resources/geo/enhanced-location-updates/invalid-wrong-type.json
@@ -13,6 +13,7 @@
     }
   },
   "skippedLocations": [],
+  "resolution": null,
   "intermediateLocations": [],
   "type": "UNEXPECTED"
 }

--- a/test-resources/geo/enhanced-location-updates/valid-full-enhanced-location-update.json
+++ b/test-resources/geo/enhanced-location-updates/valid-full-enhanced-location-update.json
@@ -27,6 +27,11 @@
       }
     }
   ],
+  "resolution": {
+    "accuracy": "BALANCED",
+    "desiredInterval": 1234,
+    "minimumDisplacement": 10.11
+  },
   "intermediateLocations": [
     {
       "type": "Feature",

--- a/test-resources/geo/enhanced-location-updates/valid-no-resolution-enhanced-location-update.json
+++ b/test-resources/geo/enhanced-location-updates/valid-no-resolution-enhanced-location-update.json
@@ -13,7 +13,6 @@
     }
   },
   "skippedLocations": [],
-  "resolution": null,
   "intermediateLocations": [],
   "type": "ACTUAL"
 }

--- a/test-resources/geo/journeys/valid-journey.json
+++ b/test-resources/geo/journeys/valid-journey.json
@@ -15,6 +15,7 @@
         }
       },
       "skippedLocations": [],
+      "resolution": null,
       "intermediateLocations": [],
       "type": "ACTUAL"
     },
@@ -37,6 +38,7 @@
         }
       },
       "skippedLocations": [],
+      "resolution": null,
       "intermediateLocations": [],
       "type": "ACTUAL"
     }

--- a/test-resources/geo/presence-data-schema.json
+++ b/test-resources/geo/presence-data-schema.json
@@ -11,27 +11,8 @@
 
     "resolution": {
       "type": ["object", "null"],
-      "properties": {
-        "accuracy": {
-          "type": "string",
-          "description": "The accuracy of GPS engine location updates.",
-          "enum": ["MINIMUM", "LOW", "BALANCED", "HIGH", "MAXIMUM"]
-        },
-
-        "desiredInterval": {
-          "type": "number",
-          "description": "The desired interval between location updates from the publisher in milliseconds.",
-          "minimum": 0
-        },
-
-        "minimumDisplacement": {
-          "type": "number",
-          "description": "The minimum distance between location updates from the publisher in meters.",
-          "minimum": 0
-        }
-      },
-      "additionalProperties": false,
-      "required": ["accuracy", "desiredInterval", "minimumDisplacement"]
+      "description": "The resolution requested by the subscriber.",
+      "$ref": "https://schemas.ably.com/json/asset-tracking-common/Resolution"
     },
 
     "rawLocations": {

--- a/test-resources/geo/raw-location-update-schema.json
+++ b/test-resources/geo/raw-location-update-schema.json
@@ -18,6 +18,12 @@
         "$ref": "https://schemas.ably.com/json/asset-tracking-common/Location"
       },
       "minLength": 0
+    },
+
+    "resolution": {
+      "type": ["object", "null"],
+      "description": "The resolution currently used by the publisher for the given trackable.",
+      "$ref": "https://schemas.ably.com/json/asset-tracking-common/Resolution"
     }
   },
   "additionalProperties": false,

--- a/test-resources/geo/raw-location-updates/valid-full-raw-location-update.json
+++ b/test-resources/geo/raw-location-updates/valid-full-raw-location-update.json
@@ -26,5 +26,10 @@
         "time": 2.0
       }
     }
-  ]
+  ],
+  "resolution": {
+    "accuracy": "BALANCED",
+    "desiredInterval": 1234,
+    "minimumDisplacement": 10.11
+  }
 }

--- a/test-resources/geo/raw-location-updates/valid-minimal-raw-location-update.json
+++ b/test-resources/geo/raw-location-updates/valid-minimal-raw-location-update.json
@@ -12,5 +12,6 @@
       "time": 2.0
     }
   },
-  "skippedLocations": []
+  "skippedLocations": [],
+  "resolution": null
 }

--- a/test-resources/geo/raw-location-updates/valid-no-resolution-raw-location-update.json
+++ b/test-resources/geo/raw-location-updates/valid-no-resolution-raw-location-update.json
@@ -12,8 +12,5 @@
       "time": 2.0
     }
   },
-  "skippedLocations": [],
-  "resolution": null,
-  "intermediateLocations": [],
-  "type": "ACTUAL"
+  "skippedLocations": []
 }

--- a/test-resources/geo/resolution-schema.json
+++ b/test-resources/geo/resolution-schema.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "Ably Asset Tracking Resolution Message",
+  "id": "https://schemas.ably.com/json/asset-tracking-common/Resolution",
+  "type": ["object", "null"],
+  "properties": {
+    "accuracy": {
+      "type": "string",
+      "description": "The accuracy of GPS engine location updates.",
+      "enum": ["MINIMUM", "LOW", "BALANCED", "HIGH", "MAXIMUM"]
+    },
+
+    "desiredInterval": {
+      "type": "number",
+      "description": "The desired interval between location updates from the publisher in milliseconds.",
+      "minimum": 0
+    },
+
+    "minimumDisplacement": {
+      "type": "number",
+      "description": "The minimum distance between location updates from the publisher in meters.",
+      "minimum": 0
+    }
+  },
+  "additionalProperties": false,
+  "required": ["accuracy", "desiredInterval", "minimumDisplacement"]
+}

--- a/test/enhanced-location-update.test.js
+++ b/test/enhanced-location-update.test.js
@@ -13,6 +13,10 @@ jsonschema.addSchema(
   JSON.parse(fs.readFileSync(path.resolve(geoDir, 'location-schema.json'))),
   'https://schemas.ably.com/json/asset-tracking-common/Location'
 );
+jsonschema.addSchema(
+  JSON.parse(fs.readFileSync(path.resolve(geoDir, 'resolution-schema.json'))),
+  'https://schemas.ably.com/json/asset-tracking-common/Resolution'
+);
 
 describe('Enhanced Location Update schema', () => {
   examples.forEach((fileName) => {

--- a/test/journey.test.js
+++ b/test/journey.test.js
@@ -14,6 +14,10 @@ jsonschema.addSchema(
   'https://schemas.ably.com/json/asset-tracking-common/Location'
 );
 jsonschema.addSchema(
+  JSON.parse(fs.readFileSync(path.resolve(geoDir, 'resolution-schema.json'))),
+  'https://schemas.ably.com/json/asset-tracking-common/Resolution'
+);
+jsonschema.addSchema(
   JSON.parse(fs.readFileSync(path.resolve(geoDir, 'enhanced-location-update-schema.json'))),
   'https://schemas.ably.com/json/asset-tracking-common/EnhancedLocationUpdate'
 );

--- a/test/presence-data.test.js
+++ b/test/presence-data.test.js
@@ -1,12 +1,18 @@
 const expect = require('chai').expect;
 const fs = require('fs');
 const path = require('path');
-const jsonschema = require('jsonschema');
+const { Validator } = require('jsonschema');
 
 const geoDir = path.resolve(__dirname, '..', 'test-resources', 'geo');
 const exampleDir = path.resolve(geoDir, 'presence-data');
 const examples = fs.readdirSync(exampleDir);
 const schema = require(path.resolve(geoDir, 'presence-data-schema.json'));
+
+const jsonschema = new Validator();
+jsonschema.addSchema(
+  JSON.parse(fs.readFileSync(path.resolve(geoDir, 'resolution-schema.json'))),
+  'https://schemas.ably.com/json/asset-tracking-common/Resolution'
+);
 
 describe('Presence data schema', () => {
   examples.forEach((fileName) => {

--- a/test/raw-location-update.test.js
+++ b/test/raw-location-update.test.js
@@ -13,6 +13,10 @@ jsonschema.addSchema(
   JSON.parse(fs.readFileSync(path.resolve(geoDir, 'location-schema.json'))),
   'https://schemas.ably.com/json/asset-tracking-common/Location'
 );
+jsonschema.addSchema(
+  JSON.parse(fs.readFileSync(path.resolve(geoDir, 'resolution-schema.json'))),
+  'https://schemas.ably.com/json/asset-tracking-common/Resolution'
+);
 
 describe('Raw Location Update schema', () => {
   examples.forEach((fileName) => {


### PR DESCRIPTION
I've added resolution data to location update schemas. This is due to the changes from issue https://github.com/ably/ably-asset-tracking-android/issues/509