### PR TITLE
Add initial AAT specification with error codes

### DIFF
--- a/specification/README.md
+++ b/specification/README.md
@@ -8,6 +8,6 @@ This document is meant to be a formal, canonical specification describing the Ab
 
 The list of Ably Asset Tracking specific error codes.
 
-| Code   | Name            | Description                                                                                                                                    |
-| ------ | --------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| Code | Name | Description |
+| ---- | ---- | ----------- |
 | 100001 | Invalid message | The SDK received a message in an unexpected format. This is treated as a fatal protocol error and the transport will be closed with a failure. |

--- a/specification/README.md
+++ b/specification/README.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-This document is meant to be a formal, canonical specification describing the Ably Asset Tracking solution.
+This document is the formal, canonical specification describing the ecosystem, including requirements, shared by components of Ably's [Asset Tracking solution](https://ably.com/solutions/asset-tracking) (AAT).
 
 ## Error codes
 

--- a/specification/README.md
+++ b/specification/README.md
@@ -1,0 +1,13 @@
+# Ably Asset Tracking Specification
+
+## Overview
+
+This document is meant to be a formal, canonical specification describing the Ably Asset Tracking solution.
+
+## Error codes
+
+The list of Ably Asset Tracking specific error codes.
+
+| Code   | Name            | Description                                                                                                                                    |
+| ------ | --------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| 100001 | Invalid message | The SDK received a message in an unexpected format. This is treated as a fatal protocol error and the transport will be closed with a failure. |


### PR DESCRIPTION
Added the `specification` directory with a `README.md` that, for now, contains the AAT specific error codes.