### PR TITLE
Add a JSON schema for the `LocationHistoryData` type

### DIFF
--- a/test-resources/geo/location-history-data-schema.json
+++ b/test-resources/geo/location-history-data-schema.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Ably Asset Tracking Location History Data",
+  "description": "Describes a sequence of locations over time, as recorded by the Ably Asset Tracking Publisher SDK.",
+  "id": "https://schemas.ably.com/json/asset-tracking-common/LocationHistoryData",
+  "type": "object",
+  "properties": {
+    "version": {
+      "const": 1
+    },
+    "events": {
+      "type": "array",
+      "description": "A sequence of locations over time, as recorded by the Publisher SDK.",
+      "items": {
+        "$ref": "https://schemas.ably.com/json/asset-tracking-common/Location"
+      }
+    }
+  }
+}

--- a/test-resources/geo/location-history-data/valid-android.json
+++ b/test-resources/geo/location-history-data/valid-android.json
@@ -1,0 +1,31 @@
+{
+  "events": [
+    {
+      "geometry": {
+        "coordinates": [-23.593555940022192, -46.65957943651529, 5],
+        "type": "Point"
+      },
+      "properties": {
+        "accuracyHorizontal": 20,
+        "bearing": 0,
+        "speed": 0,
+        "time": 1666166854.53462
+      },
+      "type": "Feature"
+    },
+    {
+      "geometry": {
+        "coordinates": [-23.593585393136074, -46.659666021490466, 5],
+        "type": "Point"
+      },
+      "properties": {
+        "accuracyHorizontal": 20,
+        "bearing": 0,
+        "speed": 0,
+        "time": 1666166854.5825229
+      },
+      "type": "Feature"
+    }
+  ],
+  "version": 1
+}

--- a/test/location-history-data.test.js
+++ b/test/location-history-data.test.js
@@ -1,0 +1,31 @@
+const expect = require('chai').expect;
+const fs = require('fs');
+const path = require('path');
+const { Validator } = require('jsonschema');
+
+const geoDir = path.resolve(__dirname, '..', 'test-resources', 'geo');
+const exampleDir = path.resolve(geoDir, 'location-history-data');
+const examples = fs.readdirSync(exampleDir);
+const schema = require(path.resolve(geoDir, 'location-history-data-schema.json'));
+
+const jsonschema = new Validator();
+jsonschema.addSchema(
+  JSON.parse(fs.readFileSync(path.resolve(geoDir, 'location-schema.json'))),
+  'https://schemas.ably.com/json/asset-tracking-common/Location'
+);
+
+describe('Location history data schema', () => {
+  examples.forEach((fileName) => {
+    console.log(`filename ${fileName}`);
+    const instance = JSON.parse(fs.readFileSync(path.resolve(exampleDir, fileName)));
+
+    it(fileName, () => {
+      const { errors } = jsonschema.validate(instance, schema);
+      if (fileName.split('-')[0] === 'invalid') {
+        expect(errors.length).to.be.greaterThan(0);
+      } else {
+        expect(errors.length).to.equal(0);
+      }
+    });
+  });
+});


### PR DESCRIPTION
Taken from the [Android model](https://github.com/ably/ably-asset-tracking-android/blob/8016b0fb97be04332d0c4d39404933a944d444fc/publishing-sdk/src/main/java/com/ably/tracking/publisher/LocationHistoryModels.kt#L12-L18).

I tested it with all of the data that had been uploaded from the Android publisher example app to the S3 bucket (the data at the top level of the bucket, not the ones in the `archive` directory).

The `valid-android.json` file is taken from the `1_2022-10-19_10/07/41` file in that bucket (with the coordinates changed for privacy of whoever recorded the data).

Closes #62.