### PR TITLE
Add ability to display callers as well as callees

### DIFF
--- a/documentation/viewer/gvpr/subgraph.gvpr
+++ b/documentation/viewer/gvpr/subgraph.gvpr
@@ -1,15 +1,20 @@
-/* Construct subgraph reachable from node ARGV[0] by forward edges
+/* Construct subgraph reachable from node ARGV[0] by forward or reverse edges
  *
  * Taken from https://forum.graphviz.org/t/print-only-specified-node-and-its-dependencies-from-large-graph/1011/4
  *
- * Usage: gvpr -f subgraph.gvpr -a addTrackable publisher.dot
+ * Usage: gvpr -f subgraph.gvpr -a addTrackable -a [forward|reverse] publisher.dot
  */
 
 BEG_G {
     node_t r = node($, ARGV[0]);
 
     $tvroot = r;
-    $tvtype = TV_fwd;
+
+    if (ARGV[1] == "forward") {
+        $tvtype = TV_fwd;
+    } else if (ARGV[1] == "reverse") {
+        $tvtype = TV_rev;
+    }
 }
 
 N {

--- a/documentation/viewer/src/app.controller.ts
+++ b/documentation/viewer/src/app.controller.ts
@@ -1,5 +1,5 @@
-import { Controller, Get, Header, Param, Render } from '@nestjs/common';
-import { AppService, DataSource } from './app.service';
+import { Controller, Get, Header, Param, Query, Render } from '@nestjs/common';
+import { AppService, DataSource, RelatedNodes } from './app.service';
 import { SdkDetailsViewModel } from './sdkDetails.viewModel';
 import { SdksViewModel } from './sdks.viewModel';
 
@@ -28,25 +28,39 @@ export class AppController {
   @Get('publisher/diagram')
   @Header('Content-Type', 'image/svg+xml')
   async generatePublisherSvgDiagram(): Promise<string> {
-    return this.appService.generateSvgDiagram('publisher', null);
+    return this.appService.generateFullSvgDiagram('publisher');
   }
 
   @Get('subscriber/diagram')
   @Header('Content-Type', 'image/svg+xml')
   async generateSubscriberSvgDiagram(): Promise<string> {
-    return this.appService.generateSvgDiagram('subscriber', null);
+    return this.appService.generateFullSvgDiagram('subscriber');
   }
 
   @Get('publisher/diagram/:nodeName')
   @Header('Content-Type', 'image/svg+xml')
-  async generatePublisherSvgDiagramForNode(@Param() params): Promise<string> {
-    return this.appService.generateSvgDiagram('publisher', params.nodeName);
+  async generatePublisherSvgDiagramForNode(
+    @Param() params,
+    @Query('relatedNodes') relatedNodes,
+  ): Promise<string> {
+    return this.appService.generateSvgDiagramForNode(
+      'publisher',
+      params.nodeName,
+      relatedNodes === 'callers' ? RelatedNodes.Callers : RelatedNodes.Callees,
+    );
   }
 
   @Get('subscriber/diagram/:nodeName')
   @Header('Content-Type', 'image/svg+xml')
-  async generateSubscriberSvgDiagramNode(@Param() params): Promise<string> {
-    return this.appService.generateSvgDiagram('subscriber', params.nodeName);
+  async generateSubscriberSvgDiagramNode(
+    @Param() params,
+    @Query('relatedNodes') relatedNodes,
+  ): Promise<string> {
+    return this.appService.generateSvgDiagramForNode(
+      'subscriber',
+      params.nodeName,
+      relatedNodes === 'callers' ? RelatedNodes.Callers : RelatedNodes.Callees,
+    );
   }
 
   private async listNodes(source: DataSource): Promise<SdkDetailsViewModel> {

--- a/documentation/viewer/src/sdkDetails.viewModel.ts
+++ b/documentation/viewer/src/sdkDetails.viewModel.ts
@@ -2,12 +2,13 @@ import { DataSource, Subgraph } from './app.service';
 
 interface SectionViewModel {
   title: string;
-  links: LinkViewModel[];
+  links: LinksViewModel[];
 }
 
-interface LinkViewModel {
+interface LinksViewModel {
   text: string;
-  href: string;
+  calleesHref: string;
+  callersHref: string;
 }
 
 export class SdkDetailsViewModel {
@@ -26,7 +27,8 @@ export class SdkDetailsViewModel {
     title: subgraph.label,
     links: subgraph.nodes.map((node) => ({
       text: node.label,
-      href: `/${this.source}/diagram/${node.name}`,
+      calleesHref: `/${this.source}/diagram/${node.name}?relatedNodes=callees`,
+      callersHref: `/${this.source}/diagram/${node.name}?relatedNodes=callers`,
     })),
   }));
 }

--- a/documentation/viewer/views/sdkDetails.njk
+++ b/documentation/viewer/views/sdkDetails.njk
@@ -11,7 +11,7 @@
     <ul>
         {% for link in section.links %}
         <li>
-            <a href="{{link.href}}">{{link.text}}</a>
+            {{link.text}} (<a href="{{link.calleesHref}}">Callees</a>, <a href="{{link.callersHref}}">Callers</a>)
         </li>
         {% endfor %}
     </ul>


### PR DESCRIPTION
This adds the ability to display a diagram showing which components call a given component ("callers"). Previously, you could only show which components a given component calls ("callees").

## Screenshots

The new options:

![image](https://user-images.githubusercontent.com/53756884/220709177-ca6d803c-32fe-4ffb-ade4-7dec61476be0.png)

An example of a caller diagram for `ChannelConnectionStateChangeWorker`:

![ChannelConnectionStateChange](https://user-images.githubusercontent.com/53756884/220709468-ed93da33-a4d3-4dcb-941b-c7e8c143ac0f.svg)
