### PR TITLE
Improve documentation of relationships between operations

### DIFF
--- a/documentation/README.md
+++ b/documentation/README.md
@@ -13,6 +13,7 @@ The operations covered are of the following types:
 - `Publisher/SubscriberInteractor` methods
 - `CorePublisher/Subscriber` public methods
 - `CorePublisher/Subscriber` private methods
+- `DefaultSubscriber` public methods
 
 This documentation is only intended to be informative, to help newcomers to the project get a rough idea of the key components of the SDK and how they interact.
 

--- a/documentation/publisher.dot
+++ b/documentation/publisher.dot
@@ -39,17 +39,17 @@ digraph {
     label = "Ably wrapper";
     node [style=filled, color=yellow];
 
-    close;
-    connect;
-    disconnect;
+    close [label=<close<BR /><FONT POINT-SIZE="10">(For all channels, it leaves presence, <BR />unsubscribes, releases, then tells the <BR />Realtime instance to close)</FONT>>];
+    connect [label=<connect<BR /><FONT POINT-SIZE="10">(Attaches to channel)</FONT>>];
+    disconnect [label=<disconnect<BR /><FONT POINT-SIZE="10">(Leaves presence, unsubscribes, releases)</FONT>>];
     enterChannelPresence;
-    startConnection;
-    stopConnection;
-    subscribeForChannelStateChange;
-    subscribeForPresenceMessages;
+    startConnection [label=<startConnection<BR /><FONT POINT-SIZE="10">(Tells the Realtime instance to connect)</FONT>>];
+    stopConnection [label=<stopConnection<BR /><FONT POINT-SIZE="10">(Tells the Realtime instance to close)</FONT>>];
+    subscribeForChannelStateChange [label=<subscribeForChannelStateChange<BR /><FONT POINT-SIZE="10">(Subscribes to channel state and emits current channel state)</FONT>>];
+    subscribeForPresenceMessages [label=<subscribeForPresenceMessages<BR /><FONT POINT-SIZE="10">(Subscribes for presence messages and optionally <BR />emits presence messages for current members)</FONT>>];
     updatePresenceData;
     waitForChannelToAttach;
-    subscribeForAblyStateChange;
+    subscribeForAblyStateChange [label=<subscribeForAblyStateChange<BR /><FONT POINT-SIZE="10">(Subscribes to connection state changes)</FONT>>];
     getChannelState;
     sendRawLocation;
     sendEnhancedLocation;

--- a/documentation/publisher.dot
+++ b/documentation/publisher.dot
@@ -234,8 +234,6 @@ digraph {
 
   // CorePublisher enqueued workers
 
-  // This is currently done in a very simplistic way: doesn’t care about which methods call other methods inside this class
-
   addTrackable -> AddTrackable;
 
   changeRoutingProfile -> ChangeRoutingProfile;
@@ -264,4 +262,28 @@ digraph {
   stop -> Stop;
 
   trackTrackable -> SetActiveTrackable;
+
+  // Method calls made internally in CorePublisher
+
+  trackTrackable -> addTrackable;
+
+  processRawLocationUpdate -> sendRawLocationUpdate;
+  processRawLocationUpdate -> processNextWaitingRawLocationUpdate;
+
+  processNextWaitingRawLocationUpdate -> processRawLocationUpdate;
+
+  retrySendingRawLocation -> sendRawLocationUpdate;
+
+  processEnhancedLocationUpdate -> sendEnhancedLocationUpdate;
+  processEnhancedLocationUpdate -> processNextWaitingEnhancedLocationUpdate;
+
+  processNextWaitingEnhancedLocationUpdate -> processEnhancedLocationUpdate;
+
+  retrySendingEnhancedLocation -> sendEnhancedLocationUpdate;
+
+  addSubscriber -> resolveResolution;
+
+  updateSubscriber -> resolveResolution;
+
+  removeSubscriber -> resolveResolution;
 }

--- a/documentation/publisher.dot
+++ b/documentation/publisher.dot
@@ -49,6 +49,10 @@ digraph {
     subscribeForPresenceMessages;
     updatePresenceData;
     waitForChannelToAttach;
+    subscribeForAblyStateChange;
+    getChannelState;
+    sendRawLocation;
+    sendEnhancedLocation;
   }
 
   subgraph CorePublisher_PublisherInteractor {
@@ -286,4 +290,12 @@ digraph {
   updateSubscriber -> resolveResolution;
 
   removeSubscriber -> resolveResolution;
+
+  // Ably wrapper methods called by CorePublisher
+
+  init -> subscribeForAblyStateChange;
+  sendEnhancedLocationUpdate -> getChannelState;
+  sendEnhancedLocationUpdate -> sendEnhancedLocation;
+  sendRawLocationUpdate -> getChannelState;
+  sendRawLocationUpdate -> sendRawLocation;
 }

--- a/documentation/publisher.dot
+++ b/documentation/publisher.dot
@@ -35,6 +35,77 @@ digraph {
     UpdatePresenceData;
   }
 
+  subgraph ably_wrapper {
+    label = "Ably wrapper";
+    node [style=filled, color=yellow];
+
+    close;
+    connect;
+    disconnect;
+    enterChannelPresence;
+    startConnection;
+    stopConnection;
+    subscribeForChannelStateChange;
+    subscribeForPresenceMessages;
+    updatePresenceData;
+    waitForChannelToAttach;
+  }
+
+  subgraph CorePublisher_PublisherInteractor {
+    label = "CorePublisher’s implementation of PublisherInteractor";
+    node [style=filled, color=purple, fontcolor=white];
+
+    addSubscriber;
+    checkThreshold;
+    closeMapbox;
+    notifyResolutionPolicyThatActiveTrackableHasChanged;
+    notifyResolutionPolicyThatTrackableWasRemoved;
+    processEnhancedLocationUpdate;
+    processNextWaitingEnhancedLocationUpdate;
+    processNextWaitingRawLocationUpdate;
+    processRawLocationUpdate;
+    removeAllSubscribers;
+    removeCurrentDestination;
+    removeSubscriber;
+    resolveResolution;
+    retrySendingEnhancedLocation;
+    retrySendingRawLocation;
+    saveEnhancedLocationForFurtherSending;
+    saveRawLocationForFurtherSending;
+    setDestination;
+    setFinalTrackableState;
+    startLocationUpdates;
+    stopLocationUpdates;
+    updateLocations;
+    updateSubscriber;
+    updateTrackableState;
+    updateTrackableStateFlows;
+    updateTrackables;
+  }
+
+  subgraph CorePublisher_public_methods {
+    label = "CorePublisher public methods";
+    node [style=filled, color=red];
+
+    init;
+    trackTrackable;
+    addTrackable;
+    changeRoutingProfile;
+    removeTrackable;
+    stop;
+  }
+
+  subgraph CorePublisher_private_methods {
+    label = "CorePublisher private methods";
+    node [style=filled, color=lightgrey];
+
+    registerLocationObserver_onEnhancedLocationChanged [label = "registerLocationObserver.onEnhancedLocationChanged"];
+    registerLocationObserver_onRawLocationChanged [label = "registerLocationObserver.onRawLocationChanged"];
+    ResolutionPolicy_Methods_refresh [label = "ResolutionPolicy.Methods.refresh"];
+    sendEnhancedLocationUpdate;
+    sendRawLocationUpdate;
+  }
+
   // Worker equivalence
 
   RetryEnterPresence -> EnterPresence [label = "WorkerFactory resolves specification to"];
@@ -72,22 +143,6 @@ digraph {
 
   // Ably wrapper methods called by workers
 
-  subgraph ably_wrapper {
-    label = "Ably wrapper";
-    node [style=filled, color=yellow];
-
-    close;
-    connect;
-    disconnect;
-    enterChannelPresence;
-    startConnection;
-    stopConnection;
-    subscribeForChannelStateChange;
-    subscribeForPresenceMessages;
-    updatePresenceData;
-    waitForChannelToAttach;
-  }
-
   AddTrackable -> connect;
   AddTrackable -> startConnection;
 
@@ -114,38 +169,6 @@ digraph {
   UpdatePresenceData -> waitForChannelToAttach;
 
   // PublisherInteractor methods called by workers
-
-  subgraph CorePublisher_PublisherInteractor {
-    label = "CorePublisher’s implementation of PublisherInteractor";
-    node [style=filled, color=purple, fontcolor=white];
-
-    addSubscriber;
-    checkThreshold;
-    closeMapbox;
-    notifyResolutionPolicyThatActiveTrackableHasChanged;
-    notifyResolutionPolicyThatTrackableWasRemoved;
-    processEnhancedLocationUpdate;
-    processNextWaitingEnhancedLocationUpdate;
-    processNextWaitingRawLocationUpdate;
-    processRawLocationUpdate;
-    removeAllSubscribers;
-    removeCurrentDestination;
-    removeSubscriber;
-    resolveResolution;
-    retrySendingEnhancedLocation;
-    retrySendingRawLocation;
-    saveEnhancedLocationForFurtherSending;
-    saveRawLocationForFurtherSending;
-    setDestination;
-    setFinalTrackableState;
-    startLocationUpdates;
-    stopLocationUpdates;
-    updateLocations;
-    updateSubscriber;
-    updateTrackableState;
-    updateTrackableStateFlows;
-    updateTrackables;
-  }
 
   AblyConnectionStateChange -> updateTrackableState;
 
@@ -210,29 +233,6 @@ digraph {
   // CorePublisher enqueued workers
 
   // This is currently done in a very simplistic way: doesn’t care about which methods call other methods inside this class
-
-  subgraph CorePublisher_public_methods {
-    label = "CorePublisher public methods";
-    node [style=filled, color=red];
-
-    init;
-    trackTrackable;
-    addTrackable;
-    changeRoutingProfile;
-    removeTrackable;
-    stop;
-  }
-
-  subgraph CorePublisher_private_methods {
-    label = "CorePublisher private methods";
-    node [style=filled, color=lightgrey];
-
-    registerLocationObserver_onEnhancedLocationChanged [label = "registerLocationObserver.onEnhancedLocationChanged"];
-    registerLocationObserver_onRawLocationChanged [label = "registerLocationObserver.onRawLocationChanged"];
-    ResolutionPolicy_Methods_refresh [label = "ResolutionPolicy.Methods.refresh"];
-    sendEnhancedLocationUpdate;
-    sendRawLocationUpdate;
-  }
 
   addTrackable -> AddTrackable;
 

--- a/documentation/publisher.dot
+++ b/documentation/publisher.dot
@@ -110,6 +110,19 @@ digraph {
     sendRawLocationUpdate;
   }
 
+  subgraph ably_wrapper_listeners {
+    node [label="listener"]
+
+    /* This is a list of all of the listeners passed to the Ably wrapper (except for the ones where the listener does not trigger a behaviour that this graph is interested in.)
+     *
+     * These nodes are given names like listener_<caller_name>__<called_name>.
+     */
+
+    listener_ConnectionReady__subscribeForChannelStateChange;
+    listener_SubscribeToPresence__subscribeForPresenceMessages;
+    listener_init__subscribeForAblyStateChange;
+  }
+
   // Worker equivalence
 
   RetryEnterPresence -> EnterPresence [label = "WorkerFactory resolves specification to"];
@@ -124,8 +137,6 @@ digraph {
 
   ConnectionReady -> FailTrackable;
   ConnectionReady -> TrackableRemovalRequested;
-  // Via the channelStateChangeListener that addTrackable passes to AddTrackable
-  ConnectionReady -> ChannelConnectionStateChange;
 
   DisconnectSuccess -> StoppingConnectionFinished;
   DisconnectSuccess -> TrackableRemovalSuccess;
@@ -139,8 +150,6 @@ digraph {
 
   SubscribeToPresence -> SubscribeToPresence;
   SubscribeToPresence -> SubscribeToPresenceSuccess;
-  // Via the presenceUpdateListener that addTrackable passes to AddTrackable
-  SubscribeToPresence -> PresenceMessage;
 
   TrackableRemovalRequested -> StoppingConnectionFinished;
   TrackableRemovalRequested -> TrackableRemovalSuccess;
@@ -242,8 +251,6 @@ digraph {
 
   changeRoutingProfile -> ChangeRoutingProfile;
 
-  init -> AblyConnectionStateChange;
-
   registerLocationObserver_onEnhancedLocationChanged -> EnhancedLocationChanged;
 
   registerLocationObserver_onRawLocationChanged -> RawLocationChanged;
@@ -298,4 +305,26 @@ digraph {
   sendEnhancedLocationUpdate -> sendEnhancedLocation;
   sendRawLocationUpdate -> getChannelState;
   sendRawLocationUpdate -> sendRawLocation;
+
+  // Methods that pass listeners
+
+  ConnectionReady -> listener_ConnectionReady__subscribeForChannelStateChange [label = "passes", style = "dashed"];
+  SubscribeToPresence -> listener_SubscribeToPresence__subscribeForPresenceMessages [label = "passes", style = "dashed"];
+  init -> listener_init__subscribeForAblyStateChange [label = "passes", style = "dashed"];
+
+  // Methods that call listeners
+
+  subscribeForChannelStateChange -> listener_ConnectionReady__subscribeForChannelStateChange;
+  subscribeForPresenceMessages -> listener_SubscribeToPresence__subscribeForPresenceMessages;
+  subscribeForAblyStateChange -> listener_init__subscribeForAblyStateChange;
+
+  // Actions performed in listeners
+
+  // Via the channelStateChangeListener that addTrackable passes to AddTrackable
+  listener_ConnectionReady__subscribeForChannelStateChange -> ChannelConnectionStateChange;
+
+  // Via the presenceUpdateListener that addTrackable passes to AddTrackable
+  listener_SubscribeToPresence__subscribeForPresenceMessages -> PresenceMessage;
+
+  listener_init__subscribeForAblyStateChange -> AblyConnectionStateChange;
 }

--- a/documentation/publisher.dot
+++ b/documentation/publisher.dot
@@ -203,6 +203,8 @@ digraph {
   PresenceMessage -> updateSubscriber;
 
   RawLocationChanged -> processRawLocationUpdate;
+  // Via the rawLocationChangedCommands that setDestination sets on the properties
+  RawLocationChanged -> setDestination;
 
   RefreshResolutionPolicy -> resolveResolution;
 

--- a/documentation/subscriber.dot
+++ b/documentation/subscriber.dot
@@ -34,6 +34,19 @@ digraph {
     ably_subscribeForRawEvents [label = "subscribeForRawEvents"];
   }
 
+  subgraph ably_wrapper_listeners {
+    node [label="listener"]
+
+    /* This is a list of all of the listeners passed to the Ably wrapper (except for the ones where the listener does not trigger a behaviour that this graph is interested in.)
+     *
+     * These nodes are given names like listener_<caller_name>__<called_name>.
+     */
+
+    listener_SubscribeForPresenceMessages__subscribeForPresenceMessages;
+    listener_CoreSubscriber_init__subscribeForAblyStateChange;
+    listener_subscribeForChannelState__subscribeForChannelStateChange;
+  }
+
   subgraph CoreSubscriber_public_methods {
     label = "CoreSubscriber public methods";
     node [style=filled, color=red];
@@ -69,7 +82,6 @@ digraph {
 
   SubscribeForPresenceMessages -> Disconnect;
   SubscribeForPresenceMessages -> ProcessInitialPresenceMessages;
-  SubscribeForPresenceMessages -> UpdatePublisherPresence;
 
   // Ably wrapper methods called by workers
 
@@ -94,12 +106,6 @@ digraph {
   SubscribeToChannel -> subscribeForEnhancedEvents;
   SubscribeToChannel -> subscribeForRawEvents;
 
-  // CoreSubscriber enqueued workers
-
-  CoreSubscriber_init -> UpdateConnectionState
-
-  subscribeForChannelState -> UpdateChannelConnectionState
-
   // DefaultSubscriber called methods
 
   DefaultSubscriber_init -> CoreSubscriber_init;
@@ -116,4 +122,22 @@ digraph {
   subscribeForChannelState -> subscribeForChannelStateChange;
   subscribeForEnhancedEvents -> ably_subscribeForEnhancedEvents;
   subscribeForRawEvents -> ably_subscribeForRawEvents;
+
+  // Methods that pass listeners
+
+  SubscribeForPresenceMessages -> listener_SubscribeForPresenceMessages__subscribeForPresenceMessages [label = "passes", style = "dashed"];
+  CoreSubscriber_init -> listener_CoreSubscriber_init__subscribeForAblyStateChange [label = "passes", style = "dashed"];
+  subscribeForChannelState -> listener_subscribeForChannelState__subscribeForChannelStateChange [label = "passes", style = "dashed"];
+
+  // Methods that call listeners
+
+  subscribeForPresenceMessages -> listener_SubscribeForPresenceMessages__subscribeForPresenceMessages;
+  subscribeForAblyStateChange -> listener_CoreSubscriber_init__subscribeForAblyStateChange;
+  subscribeForChannelStateChange -> listener_subscribeForChannelState__subscribeForChannelStateChange;
+
+  // Actions performed in listeners
+
+  listener_SubscribeForPresenceMessages__subscribeForPresenceMessages -> UpdatePublisherPresence;
+  listener_CoreSubscriber_init__subscribeForAblyStateChange -> UpdateConnectionState
+  listener_subscribeForChannelState__subscribeForChannelStateChange -> UpdateChannelConnectionState
 }

--- a/documentation/subscriber.dot
+++ b/documentation/subscriber.dot
@@ -28,6 +28,10 @@ digraph {
     startConnection;
     subscribeForPresenceMessages;
     updatePresenceData;
+    subscribeForAblyStateChange;
+    subscribeForChannelStateChange;
+    ably_subscribeForEnhancedEvents [label = "subscribeForEnhancedEvents"];
+    ably_subscribeForRawEvents [label = "subscribeForRawEvents"];
   }
 
   subgraph CoreSubscriber_public_methods {
@@ -105,4 +109,11 @@ digraph {
   start -> StartConnection;
   resolutionPreference -> ChangeResolution;
   stop -> StopConnection;
+
+  // Ably wrapper methods called by CoreSubscriber
+
+  CoreSubscriber_init -> subscribeForAblyStateChange;
+  subscribeForChannelState -> subscribeForChannelStateChange;
+  subscribeForEnhancedEvents -> ably_subscribeForEnhancedEvents;
+  subscribeForRawEvents -> ably_subscribeForRawEvents;
 }

--- a/documentation/subscriber.dot
+++ b/documentation/subscriber.dot
@@ -16,18 +16,6 @@ digraph {
     UpdatePublisherPresence;
   }
 
-  // Workers posted by workers
-
-  ProcessInitialPresenceMessages -> SubscribeToChannel;
-
-  StartConnection -> SubscribeForPresenceMessages;
-
-  SubscribeForPresenceMessages -> Disconnect;
-  SubscribeForPresenceMessages -> ProcessInitialPresenceMessages;
-  SubscribeForPresenceMessages -> UpdatePublisherPresence;
-
-  // Ably wrapper methods called by workers
-
   subgraph ably_wrapper {
     label = "Ably wrapper";
     node [style=filled, color=yellow];
@@ -41,6 +29,35 @@ digraph {
     subscribeForPresenceMessages;
     updatePresenceData;
   }
+
+  subgraph CoreSubscriber_public_methods {
+    label = "CoreSubscriber public methods";
+    node [style=filled, color=red];
+
+    init;
+  }
+
+  subgraph CoreSubscriber_SubscriberInteractor {
+    label = "CoreSubscriber’s implementation of SubscriberInteractor"
+    node [style=filled, color=purple, fontcolor=white];
+
+    notifyAssetIsOffline;
+    subscribeForChannelState;
+    subscribeForEnhancedEvents;
+    subscribeForRawEvents;
+  }
+
+  // Workers posted by workers
+
+  ProcessInitialPresenceMessages -> SubscribeToChannel;
+
+  StartConnection -> SubscribeForPresenceMessages;
+
+  SubscribeForPresenceMessages -> Disconnect;
+  SubscribeForPresenceMessages -> ProcessInitialPresenceMessages;
+  SubscribeForPresenceMessages -> UpdatePublisherPresence;
+
+  // Ably wrapper methods called by workers
 
   ChangeResolution -> updatePresenceData;
 
@@ -57,16 +74,6 @@ digraph {
 
   // SubscriberInteractor methods called by workers
 
-  subgraph CoreSubscriber_SubscriberInteractor {
-    label = "CoreSubscriber’s implementation of SubscriberInteractor"
-    node [style=filled, color=purple, fontcolor=white];
-
-    notifyAssetIsOffline;
-    subscribeForChannelState;
-    subscribeForEnhancedEvents;
-    subscribeForRawEvents;
-  }
-
   StopConnection -> notifyAssetIsOffline;
 
   SubscribeToChannel -> subscribeForChannelState;
@@ -76,13 +83,6 @@ digraph {
   // CoreSubscriber enqueued workers
 
   // This is currently done in a very simplistic way: doesn’t care about which methods call other methods inside this class
-
-  subgraph CoreSubscriber_public_methods {
-    label = "CoreSubscriber public methods";
-    node [style=filled, color=red];
-
-    init;
-  }
 
   init -> UpdateConnectionState
 

--- a/documentation/subscriber.dot
+++ b/documentation/subscriber.dot
@@ -20,16 +20,16 @@ digraph {
     label = "Ably wrapper";
     node [style=filled, color=yellow];
 
-    close;
-    connect;
-    disconnect;
+    close [label=<close<BR /><FONT POINT-SIZE="10">(For all channels, it leaves presence, <BR />unsubscribes, releases, then tells the <BR />Realtime instance to close)</FONT>>];
+    connect [label=<connect<BR /><FONT POINT-SIZE="10">(Attaches to channel)</FONT>>];
+    disconnect [label=<disconnect<BR /><FONT POINT-SIZE="10">(Leaves presence, unsubscribes, releases)</FONT>>];
     enterChannelPresence;
-    getCurrentPresence;
-    startConnection;
-    subscribeForPresenceMessages;
+    getCurrentPresence [label=<getCurrentPresence<BR /><FONT POINT-SIZE="10">(Returns a list of presence messages <BR />for current members)</FONT>>];
+    startConnection [label=<startConnection<BR /><FONT POINT-SIZE="10">(Tells the Realtime instance to connect)</FONT>>];
+    subscribeForPresenceMessages [label=<subscribeForPresenceMessages<BR /><FONT POINT-SIZE="10">(Subscribes for presence messages and optionally <BR />emits presence messages for current members)</FONT>>];
     updatePresenceData;
-    subscribeForAblyStateChange;
-    subscribeForChannelStateChange;
+    subscribeForAblyStateChange [label=<subscribeForAblyStateChange<BR /><FONT POINT-SIZE="10">(Subscribes to connection state changes)</FONT>>];
+    subscribeForChannelStateChange [label=<subscribeForChannelStateChange<BR /><FONT POINT-SIZE="10">(Subscribes to channel state and emits current channel state)</FONT>>];
     ably_subscribeForEnhancedEvents [label = "subscribeForEnhancedEvents"];
     ably_subscribeForRawEvents [label = "subscribeForRawEvents"];
   }

--- a/documentation/subscriber.dot
+++ b/documentation/subscriber.dot
@@ -92,8 +92,6 @@ digraph {
 
   // CoreSubscriber enqueued workers
 
-  // This is currently done in a very simplistic way: doesn’t care about which methods call other methods inside this class
-
   CoreSubscriber_init -> UpdateConnectionState
 
   subscribeForChannelState -> UpdateChannelConnectionState

--- a/documentation/subscriber.dot
+++ b/documentation/subscriber.dot
@@ -34,7 +34,17 @@ digraph {
     label = "CoreSubscriber public methods";
     node [style=filled, color=red];
 
-    init;
+    CoreSubscriber_init [label = "init"];
+  }
+
+  subgraph DefaultSubscriber_public_methods {
+    label = "DefaultSubscriber public methods";
+    node [style=filled, color=pink];
+
+    DefaultSubscriber_init [label = "init"];
+    start;
+    resolutionPreference;
+    stop;
   }
 
   subgraph CoreSubscriber_SubscriberInteractor {
@@ -84,7 +94,17 @@ digraph {
 
   // This is currently done in a very simplistic way: doesn’t care about which methods call other methods inside this class
 
-  init -> UpdateConnectionState
+  CoreSubscriber_init -> UpdateConnectionState
 
   subscribeForChannelState -> UpdateChannelConnectionState
+
+  // DefaultSubscriber called methods
+
+  DefaultSubscriber_init -> CoreSubscriber_init;
+
+  // DefaultSubscriber enqueued workers (by calling core.enqueue)
+
+  start -> StartConnection;
+  resolutionPreference -> ChangeResolution;
+  stop -> StopConnection;
 }

--- a/documentation/viewer/src/app.service.ts
+++ b/documentation/viewer/src/app.service.ts
@@ -64,7 +64,14 @@ export class AppService {
       }
     }
 
-    return subgraphs;
+    // The listeners aren’t of any use to present in a list to the user; they’re only interesting on the rendered graph.
+    const userFacingSubgraphs = subgraphs.filter(
+      (subgraph) =>
+        subgraph.name != 'passed_listeners' &&
+        subgraph.name != 'ably_wrapper_listeners',
+    );
+
+    return userFacingSubgraphs;
   }
 
   private async getAllNodesGvprOutput(source: DataSource): Promise<string> {

--- a/documentation/viewer/src/sdkDetails.viewModel.ts
+++ b/documentation/viewer/src/sdkDetails.viewModel.ts
@@ -26,9 +26,21 @@ export class SdkDetailsViewModel {
   readonly sections: SectionViewModel[] = this.subgraphs.map((subgraph) => ({
     title: subgraph.label,
     links: subgraph.nodes.map((node) => ({
-      text: node.label,
+      text: this.formatNodeLabel(node.label),
       calleesHref: `/${this.source}/diagram/${node.name}?relatedNodes=callees`,
       callersHref: `/${this.source}/diagram/${node.name}?relatedNodes=callers`,
     })),
   }));
+
+  private formatNodeLabel(label: string) {
+    // Strip the line break tag and anything that comes after it.
+    // I’m assuming that my node labels are of the format of a plain-text label, followed by optionally by a line break tag and some extra markup (an expanded description of the node) which we’ll omit.
+    const lineBreakIndex = label.indexOf('<BR />');
+
+    if (lineBreakIndex == -1) {
+      return label;
+    } else {
+      return label.slice(0, lineBreakIndex);
+    }
+  }
 }


### PR DESCRIPTION
This adds a bunch of improvements to the documentation introduced in https://github.com/ably/ably-asset-tracking-common/pull/74. See commit messages for more details.

As an example, here's the subscriber diagram before:

![subscriber-before](https://user-images.githubusercontent.com/53756884/220737246-155facf0-c377-45d0-bd98-5cbc865971f4.svg)

and after:

![diagram](https://user-images.githubusercontent.com/53756884/220869303-c1071f21-9fc6-423e-805e-af6794db2d75.svg)

And here’s the publisher enhanced location update diagram before:

![publisher-location-update-before](https://user-images.githubusercontent.com/53756884/220737817-66cccf90-41ac-4e95-85fd-ff942f0d8e14.svg)

and after:

![publisher-location-update-after](https://user-images.githubusercontent.com/53756884/220737829-7ca7455d-4ace-4fcd-a783-0251e3e0d5c7.svg)
